### PR TITLE
Make nedit ready for Windows compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +619,17 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix",
  "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -1053,14 +1085,16 @@ dependencies = [
 
 [[package]]
 name = "nedit"
-version = "0.4.0-unstable.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arboard",
  "chrono",
  "crossterm",
+ "dirs",
  "mlua",
  "notify",
+ "once_cell",
  "ratatui",
  "ropey",
  "serde",
@@ -1247,6 +1281,12 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -1608,6 +1648,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,7 @@ anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 chrono = "0.4"
 toml = "0.8"
+once_cell = "1.19"
+dirs = "5.0"
 mlua = { version = "0.11.6", features = ["lua54", "vendored"] }
 notify = "6.1.1"

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -78,10 +78,7 @@ impl App {
 
     pub fn new(args: &[String]) -> Self {
         let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let home_dir = std::env::var("HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from("."));
-        let config_dir = home_dir.join(".config/nedit");
+        let config_dir = Self::config_dir();
         let _ = fs::create_dir_all(&config_dir);
         let _ = fs::create_dir_all(config_dir.join("syntax"));
         let _ = fs::create_dir_all(config_dir.join("themes"));
@@ -171,10 +168,9 @@ impl App {
     }
 
     fn config_dir() -> PathBuf {
-        std::env::var("HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join(".config/nedit")
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("nedit")
     }
 
     fn load_theme_by_name(theme_name: &str, config_dir: &std::path::Path) -> Option<Theme> {

--- a/src/clipboard/clipboard.rs
+++ b/src/clipboard/clipboard.rs
@@ -1,71 +1,24 @@
-use std::io::Write;
-use std::process::{Command, Stdio};
+use arboard::Clipboard;
+use std::sync::Mutex;
+use once_cell::sync::Lazy;
 
-fn is_wayland() -> bool {
-    std::env::var("WAYLAND_DISPLAY").is_ok()
-}
+static CLIPBOARD: Lazy<Option<Mutex<Clipboard>>> = Lazy::new(|| {
+    Clipboard::new().ok().map(Mutex::new)
+});
 
 pub fn copy(text: &str) {
-    if is_wayland() {
-        if let Ok(mut child) = Command::new("wl-copy").stdin(Stdio::piped()).spawn() {
-            if let Some(stdin) = child.stdin.as_mut() {
-                let _ = stdin.write_all(text.as_bytes());
-            }
-            let _ = child.wait();
-            return;
+    if let Some(clipboard_mutex) = &*CLIPBOARD {
+        if let Ok(mut clipboard) = clipboard_mutex.lock() {
+            let _ = clipboard.set_text(text.to_string());
         }
-    }
-
-    if let Ok(mut child) = Command::new("xclip")
-        .args(["-selection", "clipboard"])
-        .stdin(Stdio::piped())
-        .spawn()
-    {
-        if let Some(stdin) = child.stdin.as_mut() {
-            let _ = stdin.write_all(text.as_bytes());
-        }
-        let _ = child.wait();
-        return;
-    }
-
-    if let Ok(mut child) = Command::new("xsel")
-        .args(["--clipboard", "--input"])
-        .stdin(Stdio::piped())
-        .spawn()
-    {
-        if let Some(stdin) = child.stdin.as_mut() {
-            let _ = stdin.write_all(text.as_bytes());
-        }
-        let _ = child.wait();
     }
 }
 
 pub fn paste() -> Option<String> {
-    if is_wayland() {
-        if let Ok(out) = Command::new("wl-paste").arg("--no-newline").output() {
-            if out.status.success() {
-                return String::from_utf8(out.stdout).ok();
-            }
+    if let Some(clipboard_mutex) = &*CLIPBOARD {
+        if let Ok(mut clipboard) = clipboard_mutex.lock() {
+            return clipboard.get_text().ok();
         }
     }
-
-    if let Ok(out) = Command::new("xclip")
-        .args(["-selection", "clipboard", "-out"])
-        .output()
-    {
-        if out.status.success() {
-            return String::from_utf8(out.stdout).ok();
-        }
-    }
-
-    if let Ok(out) = Command::new("xsel")
-        .args(["--clipboard", "--output"])
-        .output()
-    {
-        if out.status.success() {
-            return String::from_utf8(out.stdout).ok();
-        }
-    }
-
     None
 }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -23,10 +23,10 @@ fn default_theme() -> String {
 
 impl Config {
     pub fn load() -> Self {
-        let home_dir = std::env::var("HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from("."));
-        let config_path = home_dir.join(".config/nedit/config.toml");
+        let config_dir = dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("nedit");
+        let config_path = config_dir.join("config.toml");
 
         if let Ok(content) = fs::read_to_string(&config_path) {
             if let Ok(config) = toml::from_str::<Config>(&content) {


### PR DESCRIPTION
This change makes 'nedit' fully compatible with Windows by:
1. Replacing Linux-specific clipboard shell commands with the 'arboard' crate for cross-platform clipboard support.
2. Replacing hardcoded Unix-style paths and the 'HOME' environment variable with the 'dirs' crate to correctly resolve configuration directories on Windows (AppData), Linux (~/.config), and macOS.
3. Adding 'once_cell' to manage the global clipboard instance safely.
4. Ensuring that Lua integration remains portable via 'vendored' features.

---
*PR created automatically by Jules for task [4628810885671983850](https://jules.google.com/task/4628810885671983850) started by @nic-wq*