### PR TITLE
Translate Portuguese comments to English

### DIFF
--- a/tests/app.rs
+++ b/tests/app.rs
@@ -32,7 +32,7 @@ fn test_app_notification_tick() {
     let mut app = App::new(&[]);
     app.show_notification("Tick Test".to_string(), NotificationType::Info);
     
-    // Timer inicial é 5
+    // Initial timer is 5
     for _ in 0..5 {
         assert!(app.notification.is_some());
         app.tick_notification();

--- a/tests/buffer.rs
+++ b/tests/buffer.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 #[test]
 fn test_buffer_from_non_existent_path() {
-    // Caso de borda: arquivo que não existe deve criar buffer vazio com o path setado
+    // Edge case: file that does not exist should create an empty buffer with the set path
     let path = PathBuf::from("this_file_really_should_not_exist_12345.txt");
     let buffer = EditorBuffer::from_path(path.clone()).unwrap();
     
@@ -16,8 +16,8 @@ fn test_buffer_to_char_idx() {
     let mut buffer = EditorBuffer::new();
     buffer.content = ropey::Rope::from_str("line1\nline2\nline3");
     
-    // Testando conversão de linha/coluna para índice global
-    // "line1\n" é 6 chars. 'l' de "line2" está no índice 6.
+    // Testing conversion of line/column to global index
+    // "line1\n" is 6 chars. 'l' from "line2" is at index 6.
     assert_eq!(buffer.to_char_idx(1, 0), 6);
     assert_eq!(buffer.to_char_idx(0, 0), 0);
 }
@@ -27,7 +27,7 @@ fn test_buffer_char_to_line_col() {
     let mut buffer = EditorBuffer::new();
     buffer.content = ropey::Rope::from_str("abc\ndef");
     
-    // 'd' está no índice 4
+    // 'd' is at index 4
     let (line, col) = buffer.char_to_line_col(4);
     assert_eq!(line, 1);
     assert_eq!(col, 0);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,25 +1,25 @@
 use std::process::{Command, Output};
 use tempfile::TempDir;
 
-/// Retorna um diretório temporário para testes que lidam com arquivos
+/// Returns a temporary directory for tests dealing with files
 pub fn tmp_dir() -> TempDir {
-    tempfile::tempdir().expect("Falha ao criar diretório temporário")
+    tempfile::tempdir().expect("Failed to create temporary directory")
 }
 
-/// Fixture: caminho para o binário do projeto
+/// Fixture: path to the project binary
 pub fn bin_path() -> &'static str {
     env!("CARGO_BIN_EXE_nedit")
 }
 
-/// Executa o binário e retorna o Output
+/// Executes the binary and returns the Output
 pub fn run_bin(args: &[&str]) -> Output {
     Command::new(bin_path())
         .args(args)
         .output()
-        .expect("Falha ao executar o binário")
+        .expect("Failed to execute the binary")
 }
 
-/// Executa o binário e retorna (stdout, stderr, exit_code)
+/// Executes the binary and returns (stdout, stderr, exit_code)
 pub fn exec_bin(args: &[&str]) -> (String, String, i32) {
     let output = run_bin(args);
     (

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -11,7 +11,7 @@ fn test_config_get_keybind_existing() {
 #[test]
 fn test_config_get_keybind_non_existent_returns_default() {
     let config = Config::default();
-    // Ação inexistente mas que tem default mapeado
+    // Non-existent action but with a mapped default
     assert_eq!(config.get_keybind("quit"), "ctrl+q");
 }
 
@@ -28,9 +28,9 @@ fn test_config_custom_load() {
     "#;
     fs::write(&config_path, toml_content).unwrap();
     
-    // Como o Config::load() usa dirs::config_dir(), 
-    // testar o load exato é difícil sem mockar o ambiente.
-    // Mas podemos testar a desserialização manualmente se a struct for public.
+    // Since Config::load() uses dirs::config_dir(),
+    // testing the exact load is difficult without mocking the environment.
+    // But we can test deserialization manually if the struct is public.
     let config: Config = toml::from_str(toml_content).unwrap();
     assert!(!config.autocomplete_enabled);
     assert_eq!(config.theme, "monokai");

--- a/tests/integration_bin.rs
+++ b/tests/integration_bin.rs
@@ -5,11 +5,11 @@ use std::process::Command;
 
 #[test]
 fn test_bin_sem_args() {
-    // Nota: Como nedit é um TUI, ele provavelmente falha sem um TTY real.
-    // Este teste verifica o comportamento de saída nesse cenário.
+    // Note: Since nedit is a TUI, it likely fails without a real TTY.
+    // This test verifies the exit behavior in this scenario.
     let output = run_bin(&[]);
-    // Se o app falha por falta de TTY, o status code não será 0.
-    // Mas seguimos o padrão solicitado.
+    // If the app fails due to lack of TTY, the status code will not be 0.
+    // But we follow the requested pattern.
     assert!(!output.status.success() || output.status.success()); 
 }
 
@@ -17,8 +17,8 @@ fn test_bin_sem_args() {
 fn test_bin_com_arquivo_novo() {
     let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nedit"));
     cmd.arg("test_new_file.txt");
-    let output = cmd.output().expect("Falha ao executar");
-    // Apenas garantimos que o processo foi disparado
+    let output = cmd.output().expect("Failed to execute");
+    // Just ensuring the process was triggered
     assert!(output.status.code().is_some() || !output.status.success());
 }
 
@@ -26,6 +26,6 @@ fn test_bin_com_arquivo_novo() {
 fn test_bin_com_diretorio() {
     let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nedit"));
     cmd.arg(".");
-    let output = cmd.output().expect("Falha ao executar");
+    let output = cmd.output().expect("Failed to execute");
     assert!(output.status.code().is_some() || !output.status.success());
 }

--- a/tests/integration_lib.rs
+++ b/tests/integration_lib.rs
@@ -5,7 +5,7 @@ mod tests {
 
     #[test]
     fn test_config_default_load() {
-        // Happy path: garantindo que o config default carrega sem pânico
+        // Happy path: ensuring the default config loads without panic
         let config = Config::default();
         assert!(config.autocomplete_enabled);
         assert_eq!(config.get_keybind("quit"), "ctrl+q");
@@ -25,7 +25,7 @@ mod tests {
     #[test]
     fn test_buffer_line_width_calculation() {
         let mut buffer = EditorBuffer::new();
-        // Caso feliz com 1 linha
+        // Happy path with 1 line
         assert_eq!(buffer.line_number_width(), 3); // "1".len() + 2
 
         // Adicionando muitas linhas


### PR DESCRIPTION
Translated all Portuguese comments and test failure messages found in the tests/ directory to English. Verified the implementation code in src/ to ensure no Portuguese comments remained there. All tests passed after the translation.

---
*PR created automatically by Jules for task [11519253533319316543](https://jules.google.com/task/11519253533319316543) started by @nic-wq*