### PR TITLE
Fix test syntax errors and translate tests to Portuguese

### DIFF
--- a/tests/app.rs
+++ b/tests/app.rs
@@ -14,13 +14,13 @@ fn test_app_initialization() {
 fn test_app_notifications() {
     let mut app = App::new(&[]);
 
-    app.show_notification("Test Msg".to_string(), NotificationType::Info);
+    app.show_notification("Msg de Teste".to_string(), NotificationType::Info);
 
     if let Some((msg, ntype)) = &app.notification {
-        assert_eq!(msg, "Test Msg");
+        assert_eq!(msg, "Msg de Teste");
         assert!(matches!(ntype, NotificationType::Info));
     } else {
-        panic!("Notification should be set");
+        panic!("A notificação deve estar definida");
     }
 
     app.clear_notification();
@@ -30,7 +30,7 @@ fn test_app_notifications() {
 #[test]
 fn test_app_notification_tick() {
     let mut app = App::new(&[]);
-    app.show_notification("Tick Test".to_string(), NotificationType::Info);
+    app.show_notification("Teste de Tick".to_string(), NotificationType::Info);
     for _ in 0..5 {
         assert!(app.notification.is_some());
         app.tick_notification();

--- a/tests/buffer.rs
+++ b/tests/buffer.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 
 #[test]
 fn test_buffer_from_non_existent_path() {
-    // Edge case: file that does not exist should create an empty buffer with the set path
-    let path = PathBuf::from("this_file_really_should_not_exist_12345.txt");
+    // Caso de borda: arquivo que não existe deve criar um buffer vazio com o caminho definido
+    let path = PathBuf::from("este_arquivo_realmente_nao_deve_existir_12345.txt");
     let buffer = EditorBuffer::from_path(path.clone()).unwrap();
 
     assert_eq!(buffer.content.to_string(), "");
@@ -14,11 +14,11 @@ fn test_buffer_from_non_existent_path() {
 #[test]
 fn test_buffer_to_char_idx() {
     let mut buffer = EditorBuffer::new();
-    buffer.content = ropey::Rope::from_str("line1\nline2\nline3");
+    buffer.content = ropey::Rope::from_str("linha1\nlinha2\nlinha3");
     
-    // Testing conversion of line/column to global index
-    // "line1\n" is 6 chars. 'l' from "line2" is at index 6.
-    assert_eq!(buffer.to_char_idx(1, 0), 6);
+    // Testando a conversão de linha/coluna para índice global
+    // "linha1\n" tem 7 chars (considerando \n). 'l' de "linha2" está no índice 7.
+    assert_eq!(buffer.to_char_idx(1, 0), 7);
     assert_eq!(buffer.to_char_idx(0, 0), 0);
 }
 
@@ -27,7 +27,7 @@ fn test_buffer_char_to_line_col() {
     let mut buffer = EditorBuffer::new();
     buffer.content = ropey::Rope::from_str("abc\ndef");
     
-    // 'd' is at index 4
+    // 'd' está no índice 4
     let (line, col) = buffer.char_to_line_col(4);
     assert_eq!(line, 1);
     assert_eq!(col, 0);
@@ -36,10 +36,10 @@ fn test_buffer_char_to_line_col() {
 #[test]
 fn test_buffer_collect_words() {
     let mut buffer = EditorBuffer::new();
-    buffer.content = ropey::Rope::from_str("hello world hello rust_test");
+    buffer.content = ropey::Rope::from_str("ola mundo ola rust_test");
 
     let words = buffer.collect_all_words();
-    assert_eq!(words.get("hello"), Some(&2));
-    assert_eq!(words.get("world"), Some(&1));
+    assert_eq!(words.get("ola"), Some(&2));
+    assert_eq!(words.get("mundo"), Some(&1));
     assert_eq!(words.get("rust_test"), Some(&1));
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,25 +1,25 @@
 use std::process::{Command, Output};
 use tempfile::TempDir;
 
-/// Returns a temporary directory for tests dealing with files
+/// Retorna um diretório temporário para testes que lidam com arquivos
 pub fn tmp_dir() -> TempDir {
-    tempfile::tempdir().expect("Failed to create temporary directory")
+    tempfile::tempdir().expect("Falha ao criar diretório temporário")
 }
 
-/// Fixture: path to the project binary
+/// Fixture: caminho para o binário do projeto
 pub fn bin_path() -> &'static str {
     env!("CARGO_BIN_EXE_nedit")
 }
 
-/// Executes the binary and returns the Output
+/// Executa o binário e retorna o Output
 pub fn run_bin(args: &[&str]) -> Output {
     Command::new(bin_path())
         .args(args)
         .output()
-        .expect("Failed to execute the binary")
+        .expect("Falha ao executar o binário")
 }
 
-/// Executes the binary and returns (stdout, stderr, exit_code)
+/// Executa o binário e retorna (stdout, stderr, código_de_saída)
 pub fn exec_bin(args: &[&str]) -> (String, String, i32) {
     let output = run_bin(args);
     (

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -11,7 +11,7 @@ fn test_config_get_keybind_existing() {
 #[test]
 fn test_config_get_keybind_non_existent_returns_default() {
     let config = Config::default();
-    // Non-existent action but with a mapped default
+    // Ação inexistente, mas com um padrão mapeado
     assert_eq!(config.get_keybind("quit"), "ctrl+q");
 }
 
@@ -28,9 +28,9 @@ fn test_config_custom_load() {
     "#;
     fs::write(&config_path, toml_content).unwrap();
     
-    // Since Config::load() uses dirs::config_dir(),
-    // testing the exact load is difficult without mocking the environment.
-    // But we can test deserialization manually if the struct is public.
+    // Como Config::load() usa dirs::config_dir(),
+    // testar o carregamento exato é difícil sem simular o ambiente.
+    // Mas podemos testar a desserialização manualmente se a struct for pública.
     let config: Config = toml::from_str(toml_content).unwrap();
     assert!(!config.autocomplete_enabled);
     assert_eq!(config.theme, "monokai");

--- a/tests/integration_bin.rs
+++ b/tests/integration_bin.rs
@@ -1,32 +1,32 @@
 mod common;
 
 use common::run_bin;
-use std::process::Command;
 
 #[test]
-fn test_bin_sem_args() {
-    // Note: Since nedit is a TUI, it likely fails without a real TTY.
-    // This test verifies the exit behavior in this scenario.
+fn test_bin_without_args() {
+    // Nota: Como o nedit é uma TUI, ele provavelmente falha sem um TTY real.
+    // Este teste verifica o comportamento de saída neste cenário.
     let output = run_bin(&[]);
 
-    // If the app fails due to lack of TTY, the status code will not be 0.
-    // But we follow the requested pattern.
+    // Se o aplicativo falhar devido à falta de TTY, o código de status não será 0.
+    // Mas seguimos o padrão solicitado.
     assert!(!output.status.success() || output.status.success()); 
     assert!(!output.status.success() || output.status.success());
+}
 
 #[test]
-fn test_bin_com_arquivo_novo() {
+fn test_bin_with_new_file() {
     let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nedit"));
     cmd.arg("test_new_file.txt");
-    let output = cmd.output().expect("Failed to execute");
-    // Just ensuring the process was triggered
+    let output = cmd.output().expect("Falha ao executar");
+    // Apenas garantindo que o processo foi acionado
     assert!(output.status.code().is_some() || !output.status.success());
 }
 
 #[test]
-fn test_bin_com_diretorio() {
+fn test_bin_with_directory() {
     let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nedit"));
     cmd.arg(".");
-    let output = cmd.output().expect("Failed to execute");
+    let output = cmd.output().expect("Falha ao executar");
     assert!(output.status.code().is_some() || !output.status.success());
 }

--- a/tests/integration_lib.rs
+++ b/tests/integration_lib.rs
@@ -5,7 +5,7 @@ mod tests {
 
     #[test]
     fn test_config_default_load() {
-        // Happy path: ensuring the default config loads without panic
+        // Caminho feliz: garantindo que a configuração padrão carregue sem pânico
         let config = Config::default();
         assert!(config.autocomplete_enabled);
         assert_eq!(config.get_keybind("quit"), "ctrl+q");
@@ -13,10 +13,10 @@ mod tests {
 
     #[test]
     fn test_buffer_creation_happy_path() {
-        // Arrange & Act
+        // Organizar e Agir
         let buffer = EditorBuffer::new();
 
-        // Assert
+        // Assertar
         assert_eq!(buffer.content.to_string(), "");
         assert!(!buffer.modified);
         assert_eq!(buffer.cursor_row, 0);
@@ -25,7 +25,7 @@ mod tests {
     #[test]
     fn test_buffer_line_width_calculation() {
         let mut buffer = EditorBuffer::new();
-        // Happy path with 1 line
+        // Caminho feliz com 1 linha
         assert_eq!(buffer.line_number_width(), 3); // "1".len() + 2
 
         // Adicionando muitas linhas


### PR DESCRIPTION
This PR fixes a syntax error in the integration tests and translates the entire test suite documentation (comments and messages) to Portuguese, while ensuring that test function names remain in English. It also adjusts character index calculations in `tests/buffer.rs` to maintain test correctness after string translations.

---
*PR created automatically by Jules for task [11007702063218968759](https://jules.google.com/task/11007702063218968759) started by @nic-wq*